### PR TITLE
close paren would be first occurrence

### DIFF
--- a/R/parse_r_script.R
+++ b/R/parse_r_script.R
@@ -10,7 +10,7 @@ parse_r_script <- function(file, library_pattern = '^\\s*(library|require)\\(\\S
 #' Parses the name of the library to be loaded
 parse_load <- function(load_command){
     open_paren <- regexpr(pattern = '\\(', text = load_command)[1]
-    close_paren <- regexpr(pattern = '\\)$', text = load_command)[1]
+    close_paren <- regexpr(pattern = '\\)', text = load_command)[1]
     substr(x = load_command, start = open_paren + 1, stop = close_paren - 1)
 }
 


### PR DESCRIPTION
instead of looking for the closing paren at the end of the line.
This will fix instances where there are comments after a library call.
Some people comment library loads to remind themselves what the library is used for
